### PR TITLE
Adding snippet of source code for mat_ptr change

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Ray Tracing in One Weekend
 The _Ray Tracing in One Weekend_ series of books are now available to the public for free in PDF
 form, along with the accompanying source code.
 
-Releases are available [directly from GitHub][releases], or from Eric Haine's [Real-Time
-Rendering][] site. Alternatively, you can purchase the Kindle version of this series from
+Releases are available [directly from GitHub][releases], or from Eric Haines's
+[Real-Time Rendering][] site. Alternatively, you can purchase the Kindle version of this series from
 [Amazon.com][]. Half of the proceeds of these sales go to [Hack the Hood][], a really neat
 organization.
 

--- a/book/ch08.md.html
+++ b/book/ch08.md.html
@@ -64,6 +64,45 @@ group. When a ray hits a surface (a particular sphere for example), the material
 `main()` when we start. When the `color()` routine gets the `hit_record` it can call member
 functions of the material pointer to find out what ray, if any, is scattered.
 
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    class sphere: public hitable  {
+        public:
+            sphere() {}
+            sphere(vec3 cen, float r, material *m) : center(cen), radius(r), mat_ptr(m)  {};
+            virtual bool hit(const ray& r, float tmin, float tmax, hit_record& rec) const;
+            vec3 center;
+            float radius;
+            material *mat_ptr; /* NEW */
+    };
+
+    bool sphere::hit(const ray& r, float t_min, float t_max, hit_record& rec) const {
+        vec3 oc = r.origin() - center;
+        float a = dot(r.direction(), r.direction());
+        float b = dot(oc, r.direction());
+        float c = dot(oc, oc) - radius*radius;
+        float discriminant = b*b - a*c;
+        if (discriminant > 0) {
+            float temp = (-b - sqrt(discriminant))/a;
+            if (temp < t_max && temp > t_min) {
+                rec.t = temp;
+                rec.p = r.point_at_parameter(rec.t);
+                rec.normal = (rec.p - center) / radius;
+                rec.mat_ptr = mat_ptr; /* NEW */
+                return true;
+            }
+            temp = (-b + sqrt(discriminant)) / a;
+            if (temp < t_max && temp > t_min) {
+                rec.t = temp;
+                rec.p = r.point_at_parameter(rec.t);
+                rec.normal = (rec.p - center) / radius;
+                rec.mat_ptr = mat_ptr; /* NEW */
+                return true;
+            }
+        }
+        return false;
+    }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 For the Lambertian (diffuse) case we already have, it can either scatter always and attenuate by its
 reflectance $R$, or it can scatter with no attenuation but absorb the fraction $1-R$ of the rays. Or
 it could be a mixture of those strategies. For Lambertian materials we get this simple class:


### PR DESCRIPTION
I am very lazy and to avoid cheating by copying paste, I write the code
my own. I know the src code already has this mat_ptr for hit_record set,
but I think it could be helpful to explicitly say that hit_record needs
the mat_ptr on sphere::hit.