### PR TITLE
 Adding snippet of source code for mat_ptr change

### DIFF
--- a/book/ch08.md.html
+++ b/book/ch08.md.html
@@ -64,6 +64,45 @@ group. When a ray hits a surface (a particular sphere for example), the material
 `main()` when we start. When the `color()` routine gets the `hit_record` it can call member
 functions of the material pointer to find out what ray, if any, is scattered.
 
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
+    class sphere: public hitable  {
+        public:
+            sphere() {}
+            sphere(vec3 cen, float r, material *m) : center(cen), radius(r), mat_ptr(m)  {};
+            virtual bool hit(const ray& r, float tmin, float tmax, hit_record& rec) const;
+            vec3 center;
+            float radius;
+            material *mat_ptr; /* NEW */
+    };
+
+    bool sphere::hit(const ray& r, float t_min, float t_max, hit_record& rec) const {
+        vec3 oc = r.origin() - center;
+        float a = dot(r.direction(), r.direction());
+        float b = dot(oc, r.direction());
+        float c = dot(oc, oc) - radius*radius;
+        float discriminant = b*b - a*c;
+        if (discriminant > 0) {
+            float temp = (-b - sqrt(discriminant))/a;
+            if (temp < t_max && temp > t_min) {
+                rec.t = temp;
+                rec.p = r.point_at_parameter(rec.t);
+                rec.normal = (rec.p - center) / radius;
+                rec.mat_ptr = mat_ptr; /* NEW */
+                return true;
+            }
+            temp = (-b + sqrt(discriminant)) / a;
+            if (temp < t_max && temp > t_min) {
+                rec.t = temp;
+                rec.p = r.point_at_parameter(rec.t);
+                rec.normal = (rec.p - center) / radius;
+                rec.mat_ptr = mat_ptr; /* NEW */
+                return true;
+            }
+        }
+        return false;
+    }
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 For the Lambertian (diffuse) case we already have, it can either scatter always and attenuate by its
 reflectance $R$, or it can scatter with no attenuation but absorb the fraction $1-R$ of the rays. Or
 it could be a mixture of those strategies. For Lambertian materials we get this simple class:

--- a/book/ch08.md.html
+++ b/book/ch08.md.html
@@ -81,7 +81,7 @@ within `hit_record`. See the lines below marked with **`/* NEW */`**.
             vec3 center;
             float radius;
 	    material *mat_ptr; /* NEW */
-        };
+    };
 
     bool sphere::hit(const ray& r, float t_min, float t_max, hit_record& rec) const {
         vec3 oc = r.origin() - center;

--- a/book/ch08.md.html
+++ b/book/ch08.md.html
@@ -95,7 +95,7 @@ within `hit_record`. See the lines below marked with **`/* NEW */`**.
                 rec.t = temp;
                 rec.p = r.point_at_parameter(rec.t);
                 rec.normal = (rec.p - center) / radius;
-		rec.mat_ptr = mat_ptr; /* NEW */
+                rec.mat_ptr = mat_ptr; /* NEW */
                 return true;
             }
             temp = (-b + sqrt(discriminant)) / a;

--- a/book/ch08.md.html
+++ b/book/ch08.md.html
@@ -64,16 +64,24 @@ group. When a ray hits a surface (a particular sphere for example), the material
 `main()` when we start. When the `color()` routine gets the `hit_record` it can call member
 functions of the material pointer to find out what ray, if any, is scattered.
 
+To achieve this, we must have a reference to the material for our sphere class to returned
+within `hit_record`. See the lines below marked with **`/* NEW */`**.
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ C++
     class sphere: public hitable  {
         public:
             sphere() {}
-            sphere(vec3 cen, float r, material *m) : center(cen), radius(r), mat_ptr(m)  {};
-            virtual bool hit(const ray& r, float tmin, float tmax, hit_record& rec) const;
+            sphere(vec3 cen, float r, material *m) : center(cen),
+                                                     radius(r),
+                                                     mat_ptr(m)  {};
+            virtual bool hit(const ray& r,
+                             float tmin,
+                             float tmax,
+                             hit_record& rec) const;
             vec3 center;
             float radius;
-            material *mat_ptr; /* NEW */
-    };
+	    material *mat_ptr; /* NEW */
+        };
 
     bool sphere::hit(const ray& r, float t_min, float t_max, hit_record& rec) const {
         vec3 oc = r.origin() - center;
@@ -87,7 +95,7 @@ functions of the material pointer to find out what ray, if any, is scattered.
                 rec.t = temp;
                 rec.p = r.point_at_parameter(rec.t);
                 rec.normal = (rec.p - center) / radius;
-                rec.mat_ptr = mat_ptr; /* NEW */
+		rec.mat_ptr = mat_ptr; /* NEW */
                 return true;
             }
             temp = (-b + sqrt(discriminant)) / a;

--- a/src/sphere.h
+++ b/src/sphere.h
@@ -17,7 +17,9 @@
 class sphere: public hitable  {
     public:
         sphere() {}
-        sphere(vec3 cen, float r, material *m) : center(cen), radius(r), mat_ptr(m)  {};
+        sphere(vec3 cen, float r, material *m) : center(cen),
+						 radius(r),
+						 mat_ptr(m)  {};
         virtual bool hit(const ray& r, float tmin, float tmax, hit_record& rec) const;
         vec3 center;
         float radius;


### PR DESCRIPTION
I am very lazy and to avoid cheating by copying paste, I write the code
my own. I know the src code already has this mat_ptr for hit_record set,
but I think it could be helpful to explicitly say that hit_record needs
the mat_ptr on sphere::hit.