### PR TITLE
book: initial CSS structure

### DIFF
--- a/assets/book.css
+++ b/assets/book.css
@@ -1,0 +1,29 @@
+body {
+}
+
+/* Under-Development Warning Box */
+
+div.warning {
+    background: #fee;
+    margin:     1em 4em 4em 4em;
+    border:     solid 4px red;
+    padding:    0em 4ex 1em 4ex;
+}
+
+div.warning a {
+    font-family: sans-serif;
+}
+
+div.warning p {
+    font-family: sans-serif;
+    font-size:   100%;
+    font-weight: normal;
+    color:       black;
+}
+
+div.warning p.title {
+    font-family: sans-serif;
+    font-size:   160%;
+    font-weight: bold;
+    color:       red;
+}

--- a/book/ack.md.html
+++ b/book/ack.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
                                         **Acknowledgements**
@@ -15,6 +17,7 @@ help on the figures. Thanks to Fabio San for pull requests.
 [limnu.com]: https://limnu.com/
 
 <!-- Markdeep: https://casual-effects.com/markdeep/ -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch00.md.html
+++ b/book/ch00.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
                                    **Ray Tracing in One Weekend**
@@ -56,6 +58,7 @@ Let’s get on with it!
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch01.md.html
+++ b/book/ch01.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -89,6 +91,7 @@ If you want to produce more image types than PPM, I am a fan of `stb_image.h` av
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch02.md.html
+++ b/book/ch02.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -185,6 +187,7 @@ Now we can change our main to use this:
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch03.md.html
+++ b/book/ch03.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -110,6 +112,7 @@ with $t$ going from zero to one. In our case this produces:
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch04.md.html
+++ b/book/ch04.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -95,6 +97,7 @@ you. This is not a feature! We’ll fix those issues next.
 </style>
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch05.md.html
+++ b/book/ch05.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -235,6 +237,7 @@ surface normal. This is often a great way to look at your model for flaws and ch
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch06.md.html
+++ b/book/ch06.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -98,6 +100,7 @@ and part foreground:
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch07.md.html
+++ b/book/ch07.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -102,6 +104,7 @@ This gets rid of the shadow acne problem. Yes it is really called that.
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch08.md.html
+++ b/book/ch08.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -222,6 +224,7 @@ We can try that out by adding fuzziness 0.3 and 1.0 to the metals:
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch09.md.html
+++ b/book/ch09.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -189,6 +191,7 @@ This gives:
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch10.md.html
+++ b/book/ch10.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -139,6 +141,7 @@ And we can change field of view to get:
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch11.md.html
+++ b/book/ch11.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -109,6 +111,7 @@ We get:
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/book/ch12.md.html
+++ b/book/ch12.md.html
@@ -1,8 +1,10 @@
 <meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -91,6 +93,7 @@ Have fun, and please send me your cool images!
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='../assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="../assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -1,8 +1,10 @@
-<meta charset="utf-8">
-<div style="background:#fee; margin: 1em 4em 4em 4em; border:solid 4px red; padding: 0em 4ex 1em 4ex;">
-<p style="font-size:160%; font-weight:bold; color:red;">WARNING<br>Content Under Development</p>
-See <a href="https://github.com/RayTracing/raytracinginoneweekend/releases">release page</a> for
-latest official PDF version.</div>
+<meta charset='utf-8'>
+
+<div class='warning'>
+  <p class='title'>WARNING<br>Content Under Development</h1>
+  <p class='text'>
+    See <a href='https://github.com/raytracing/InOneWeekend/releases'>release page</a> for latest official PDF version.
+</div>
 
 
 
@@ -25,6 +27,7 @@ latest official PDF version.</div>
 
 
 <!-- Markdeep: -->
+<link rel='stylesheet' href='assets/book.css'>
 <style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style>
 <script src="assets/markdeep.min.js"></script>
 <script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>


### PR DESCRIPTION
This will be a pain, as we'll need to replicate CSS stylesheet changes
across all repos/books, rather than fetching from a common source on the
web. The reason for this approach is that the whole release package
should be whole, and consumable without an internet connection.

In future work, print media queries will allow us to tune the print form
of these books, and can be used to generate PDF versions.