### PR TITLE
Sync book cross product with source code

### DIFF
--- a/book/ch02.md.html
+++ b/book/ch02.md.html
@@ -108,9 +108,9 @@ operations:
     }
 
     inline vec3 cross(const vec3 &v1, const vec3 &v2) {
-        return vec3( (v1.e[1]*v2.e[2] - v1.e[2]*v2.e[1]),
-                    (-(v1.e[0]*v2.e[2] - v1.e[2]*v2.e[0])),
-                    (v1.e[0]*v2.e[1] - v1.e[1]*v2.e[0]));
+        return vec3(v1.e[1] * v2.e[2] - v1.e[2] * v2.e[1],
+                    v1.e[2] * v2.e[0] - v1.e[0] * v2.e[2],
+                    v1.e[0] * v2.e[1] - v1.e[1] * v2.e[0]);
     }
 
     inline vec3& vec3::operator+=(const vec3 &v){


### PR DESCRIPTION
The source code version of the cross product implementation already was updated to multiply the minus into the formula for the second component as suggested in https://github.com/RayTracing/InOneWeekend/issues/16. This commit updates the book  to match this.

Fixes https://github.com/RayTracing/InOneWeekend/issues/16.